### PR TITLE
生のパスワードを極力持ったままにしないよう修正

### DIFF
--- a/extension/js/credential.js
+++ b/extension/js/credential.js
@@ -2,32 +2,42 @@ import CryptoJS from './vendor/crypto-js.js';
 
 /**
  * 認証情報を暗号化して管理するクラス
- * using crypto-js
- * https://code.google.com/p/crypto-js/#The_Cipher_Output
  */
 export default class Credential {
   static async retrieve() {
     try {
       const { credential } = await chrome.storage.sync.get('credential');
       const { companycd, logincd, encrypted, secret } = JSON.parse(credential);
-      const password = CryptoJS.AES.decrypt(encrypted, secret).toString(CryptoJS.enc.Utf8);
-      return new Credential(companycd, logincd, password);
+      return new Credential(companycd, logincd, encrypted, secret);
     } catch {
       return new Credential();
     }
   }
 
-  constructor(companycd = '', logincd = '', password = '') {
-    this.companycd = companycd;
-    this.logincd = logincd;
-    this.password = password;
+  constructor(companycd = '', logincd = '', password = '', secret = null) {
+    this.data = { companycd, logincd, encrypted: password, secret };
+
+    if (secret === null) {
+      this.data.secret = CryptoJS.lib.WordArray.random(128/8).toString(CryptoJS.enc.Base64);
+      this.data.encrypted = CryptoJS.AES.encrypt(password, this.data.secret).toString();
+    }
+  }
+
+  companycd() {
+    return this.data.companycd;
+  }
+
+  logincd() {
+    return this.data.logincd;
+  }
+
+  password() {
+    const { encrypted, secret } = this.data;
+    return CryptoJS.AES.decrypt(encrypted, secret).toString(CryptoJS.enc.Utf8);
   }
 
   async save() {
-    const { companycd, logincd, password } = this;
-    const secret = CryptoJS.lib.WordArray.random(128/8).toString(CryptoJS.enc.Base64);
-    const encrypted = CryptoJS.AES.encrypt(password, secret).toString();
-    const credential = JSON.stringify({ companycd, logincd, encrypted, secret });
+    const credential = JSON.stringify(this.data);
     await chrome.storage.sync.set({ credential });
   }
 

--- a/extension/js/kinnosuke.js
+++ b/extension/js/kinnosuke.js
@@ -197,9 +197,9 @@ class KinnosukeClient {
   login(credential) {
     return this.post({
       module: 'login',
-      y_companycd: credential.companycd,
-      y_logincd: credential.logincd,
-      password: credential.password,
+      y_companycd: credential.companycd(),
+      y_logincd: credential.logincd(),
+      password: credential.password(),
       trycnt: 1,
     });
   }

--- a/extension/js/options.js
+++ b/extension/js/options.js
@@ -19,9 +19,9 @@ const saveOptions = async () => {
 
 const restoreOptions = async () => {
   const credential = await Credential.retrieve();
-  document.getElementById('companycd').value = credential.companycd;
-  document.getElementById('logincd').value = credential.logincd;
-  document.getElementById('password').value = credential.password;
+  document.getElementById('companycd').value = credential.companycd();
+  document.getElementById('logincd').value = credential.logincd();
+  document.getElementById('password').value = credential.password();
 };
 
 document.addEventListener('DOMContentLoaded', restoreOptions);

--- a/extension/js/vendor/crypto-js.js
+++ b/extension/js/vendor/crypto-js.js
@@ -1,3 +1,7 @@
+/**
+ * importできるようにビルドする方法が分からなかったので、
+ * コードを直接書き換えてexportしちゃってます。。。
+ */
 const CryptoJS = (() => {
   /**
    * CryptoJS core components.


### PR DESCRIPTION
今まではstorageから取り出したら復号し、保存する際に暗号化していましたが、以下のように修正しました。

* storageから取り出した暗号化パスワードをそのままインスタンスに保持
* コンストラクタに生パスワードが渡されたら暗号化してインスタンスに保持
* passwordメソッドで取り出す際に復号
